### PR TITLE
Fixed session reuse detected error when no captcha point was disabled

### DIFF
--- a/captcha.module
+++ b/captcha.module
@@ -501,7 +501,8 @@ function _captcha_get_posted_captcha_info(array $element, FormStateInterface $fo
       preg_replace("/[^a-zA-Z0-9]/", "", (string) $input['captcha_token'])
       : NULL;
 
-    if ($posted_form_id == $this_form_id) {
+    $form_id_setting = captcha_get_form_id_setting($this_form_id);
+    if ($posted_form_id == $this_form_id && $form_id_setting->getCaptchaType() != 'none') {
       // Check if the posted CAPTCHA token is valid for the posted CAPTCHA
       // session ID. Note that we could just check the validity of the CAPTCHA
       // token and extract the CAPTCHA session ID from that (without looking at


### PR DESCRIPTION
Somehow the session reuse detection didn't check whether the captcha was enabled on that form at all. Probably more complex error in general than this quickfix treats, but captcha could use a proper port.
